### PR TITLE
fix: resolve #109 — Improve the responsivity in DataTable comp.

### DIFF
--- a/src/components/commons/ResizableTh.jsx
+++ b/src/components/commons/ResizableTh.jsx
@@ -1,0 +1,80 @@
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import './ResizableTh.css';
+
+const ResizableTh = ({ children, width, onResize, minWidth = 50, maxWidth = 600 }) => {
+  const [colWidth, setColWidth] = useState(width);
+  const [isResizing, setIsResizing] = useState(false);
+  const thRef = useRef(null);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+
+  const handleMouseDown = useCallback((e) => {
+    e.preventDefault();
+    setIsResizing(true);
+    startXRef.current = e.clientX;
+    startWidthRef.current = thRef.current ? thRef.current.offsetWidth : colWidth;
+  }, [colWidth]);
+
+  const handleMouseMove = useCallback((e) => {
+    if (!isResizing) return;
+
+    const diff = e.clientX - startXRef.current;
+    const newWidth = Math.max(minWidth, Math.min(maxWidth, startWidthRef.current + diff));
+    setColWidth(newWidth);
+
+    if (onResize) {
+      onResize(newWidth);
+    }
+  }, [isResizing, minWidth, maxWidth, onResize]);
+
+  const handleMouseUp = useCallback(() => {
+    setIsResizing(false);
+  }, []);
+
+  useEffect(() => {
+    if (isResizing) {
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    }
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isResizing, handleMouseMove, handleMouseUp]);
+
+  useEffect(() => {
+    if (width !== undefined) {
+      setColWidth(width);
+    }
+  }, [width]);
+
+  return (
+    <th
+      ref={thRef}
+      className={`resizable-th ${isResizing ? 'is-resizing' : ''}`}
+      style={{ minWidth: `${minWidth}px`, width: `${colWidth}px` }}
+    >
+      <div className="resizable-th-content">
+        <span className="resizable-th-text">{children}</span>
+      </div>
+      <div
+        className="resizable-th-handle"
+        onMouseDown={handleMouseDown}
+        role="separator"
+        aria-orientation="vertical"
+      />
+    </th>
+  );
+};
+
+ResizableTh.propTypes = {
+  children: PropTypes.node.isRequired,
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  onResize: PropTypes.func,
+  minWidth: PropTypes.number,
+  maxWidth: PropTypes.number,
+};
+
+export default ResizableTh;

--- a/src/components/commons/index.css
+++ b/src/components/commons/index.css
@@ -2,3 +2,48 @@
     min-height: 100px;
   }
    */
+
+/* DataTable Responsive Styles */
+.table-container {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+  padding: 12px 8px;
+  font-size: 14px;
+}
+
+@media (max-width: 768px) {
+  .data-table {
+    font-size: 12px;
+  }
+
+  .data-table th,
+  .data-table td {
+    padding: 8px 6px;
+  }
+
+  .table-container {
+    display: block;
+    width: 100%;
+    overflow-x: scroll;
+  }
+}
+
+@media (max-width: 480px) {
+  .data-table {
+    font-size: 11px;
+  }
+
+  .data-table th,
+  .data-table td {
+    padding: 6px 4px;
+  }
+}


### PR DESCRIPTION
## Summary

fix: resolve #109 — Improve the responsivity in DataTable comp.

## Problem

**Severity**: `Medium` | **File**: `src/components/commons/ResizableTh.jsx`

The ResizableTh component handles table header resizing. It needs updates to ensure headers remain readable and properly sized on smaller screens while maintaining drag-to-resize functionality.

## Solution



## Changes

- `src/components/commons/ResizableTh.jsx` (new)
- `src/components/commons/index.css` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*